### PR TITLE
fix import from laverna v0.7.51

### DIFF
--- a/src/scripts/components/Sync.js
+++ b/src/scripts/components/Sync.js
@@ -176,4 +176,5 @@ export default class Sync {
         const opt = _.extend(options);
         return this.db.dropDb(model);
     }
+
 }

--- a/src/scripts/components/importExport/migrate/Encryption.js
+++ b/src/scripts/components/importExport/migrate/Encryption.js
@@ -79,8 +79,10 @@ export default class Encryption {
         if ((!text || !text.length) || !this.configs.encrypt) {
             return text;
         }
-
-        return sjcl.decrypt(this.keys.key, text);
+        const d = sjcl.decrypt(this.keys.key, text);
+        console.log("migrate: decrypt(): data")
+        console.log(d);
+        return d;
     }
 
     /**


### PR DESCRIPTION
Apparently old laverna dev branch import code didn't actually do anything different with 0.7.51 files if they got imported.  You could migrate if the files were already there, and there was the start of some code there to check if they were the old format, but then they just got imported like regular files, which would make them fail. 

Instead of trying to import the lav 0.7.51 data, this just puts it into notes-db (where 0.7.51 would keep it) and then we trigger the migration view, which actually does work.  I also fixed a bug that was causing the old config file to not be read properly, thus causing migration to fail occasionally.