### PR TITLE
Fix #56: OpenPGP key importation in new identity form

### DIFF
--- a/src/scripts/components/setup/register/template.html
+++ b/src/scripts/components/setup/register/template.html
@@ -8,8 +8,8 @@
     </div>
 
     <div class="col-xs-12">
-        <input id="import--data" class="hide" type="file">
-        <button data-file="#import--data" type="button" class="btn btn-default btn-block btn-success btn--import -small">
+        <input id="import--key" class="hide" type="file">
+        <button data-file="#import--key" type="button" class="btn btn-default btn-block btn-success btn--import -small">
             <i class="icon-key"></i> {{ _.i18n('Upload existing OpenPGP key') }}
         </button>
         <br />


### PR DESCRIPTION
The event `checkFile` was being associated to a change in `#import--key` but the template field was named `#import--data`

This fixes issue #56 