### PR TITLE
Change styling of btn-secondary in Dark theme

### DIFF
--- a/src/styles/theme-dark/theme.less
+++ b/src/styles/theme-dark/theme.less
@@ -74,6 +74,12 @@ hr {
         color            : #FFF;
     }
 }
+.btn-secondary {
+    background-color: @theme-primary;
+    &:hover {
+        color: @theme-success;
+    }
+}
 .btn-warning {
     background-color: @theme-warning;
     &:hover {


### PR DESCRIPTION
Hello! I noticed in the dark theme that the New Tag and New Notebook buttons were poorly styled because the styling for the btn-secondary was missing. I added it, and it works fine now with clear button styling for those two. 

I will keep working on more styling for the UI if this project is still active. 