### PR TITLE
Change favicon to transparent one

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Encryptic</title>
         <meta name="description" content="Note taking web app with markdown support">
+        <link rel="shortcut icon" type="image/png" href="images/encryptic-web2.0-transparent.png">
         <meta name="format-detection" content="telephone=no">
         <meta name="viewport" content="user-scalable=no, initial-scale=1,
             maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
@@ -17,10 +18,10 @@
         <link rel="apple-touch-icon" sizes="152x152" href="images/icon/icon-152x152.png">
         <!-- Add to home screen support (Android) -->
         <meta name="mobile-web-app-capable" content="yes">
-        <link rel="icon" sizes="36x36" href="images/icon/icon-36x36.png">
-        <link rel="icon" sizes="72x72" href="images/icon/icon-72x72.png">
-        <link rel="icon" sizes="48x48" href="images/icon/icon-48x48.png">
-        <link rel="icon" sizes="96x96" href="images/icon/icon-96x96.png">
+        <link rel="android-icon" sizes="36x36" href="images/icon/icon-36x36.png">
+        <link rel="android-icon" sizes="72x72" href="images/icon/icon-72x72.png">
+        <link rel="android-icon" sizes="48x48" href="images/icon/icon-48x48.png">
+        <link rel="android-icon" sizes="96x96" href="images/icon/icon-96x96.png">
         <!-- Microsoft Windows 8 & Phone start screen tile support -->
         <meta name="application-name" content="Encryptic" />
         <meta name="msapplication-TileColor" content="#006C60" />


### PR DESCRIPTION
The favicon with white background was bugging me. Found out that because the Android home icons were named as rel="icon", the browser would use this data as favicon. I changed their rel to android-icon, and added a real favicon line.