### PR TITLE
Show error when port 9000 is in use

### DIFF
--- a/gulps/serve.js
+++ b/gulps/serve.js
@@ -7,19 +7,37 @@
  */
 module.exports = (gulp, $) => {
     return () => {
-        $.browserSync.init({
-            notify    : false,
-            open      : !$.minimist.dev,
-            server    : $.minimist.root || $.distDir,
-            port      : $.minimist.port || 9000,
-            ghostMode : $.minimist.ghostMode !== undefined,
+        return new Promise((_, reject) => {
+            const port = $.minimist.port || 9000;
+
+            // why is this SO HUGGING HARD to just add something like
+            // instance.options.url or just an option to abort if the port is in use ?
+            $.browserSync.init({
+                port,
+                notify    : false,
+                open      : false,
+                server    : $.minimist.root || $.distDir,
+                ghostMode : $.minimist.ghostMode !== undefined,
+            }, function() {
+                if (this.server.address().port !== port) {
+                    reject('[ERROR] Could not serve: port 9000 is in use.');
+                }
+
+                if (!$.minimist.dev) {
+                    this.utils.openBrowser(
+                        this.options.get('urls').toJS().local,
+                        this.options.set('open', true),
+                        this
+                    );
+                }
+
+                // Watch for changes in SASS and HTML
+                gulp.watch('./src/styles/**/*.less', gulp.series('css'));
+                gulp.watch('./src/*.html', gulp.series('html'));
+
+                // Re-bundle if some new packages were installed
+                gulp.watch('package.json', gulp.series('bundle'));
+            });
         });
-
-        // Watch for changes in SASS and HTML
-        gulp.watch('./src/styles/**/*.less', gulp.series('css'));
-        gulp.watch('./src/*.html', gulp.series('html'));
-
-        // Re-bundle if some new packages were installed
-        gulp.watch('package.json', gulp.series('bundle'));
     };
 };

--- a/gulps/serve.js
+++ b/gulps/serve.js
@@ -20,7 +20,7 @@ module.exports = (gulp, $) => {
                 ghostMode : $.minimist.ghostMode !== undefined,
             }, function() {
                 if (this.server.address().port !== port) {
-                    reject('[ERROR] Could not serve: port 9000 is in use.');
+                    reject('port 9000 is in use.');
                 }
 
                 if (!$.minimist.dev) {


### PR DESCRIPTION
Display an error and abort gulp if port 9000 is in use when using gulp serve