### PR TITLE
Prefix application startup with dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:10.12-alpine
 
+RUN apk add --no-cache dumb-init
+
 RUN npm install -g gulp yarn
 
 ADD . /app
@@ -7,5 +9,7 @@ ADD . /app
 WORKDIR /app
 
 RUN yarn
+
+ENTRYPOINT [ "dumb-init", "--" ]
 
 CMD [ "gulp" ]


### PR DESCRIPTION
Sorry for the cold-pull-request, I'm not too well versed in github pull request etiquette; thanks for this project, it's great, I've been looking for something like this for the longest time and suddenly saw it today in `r/selfhosted`.

While testing the docker build and docker run on the command line I found that the container wouldn't stop when I pressed ^C, so I added `dumb-init` to the application initialization and that fixed it.  It'll make application exit cleaner, since docker won't have to kill the process without giving it a chance to clean up after itself.

Dumb init is developed here: https://github.com/Yelp/dumb-init